### PR TITLE
Add tests for Update Delivery Status endpoint

### DIFF
--- a/src/test/java/com/example/AppTest.java
+++ b/src/test/java/com/example/AppTest.java
@@ -96,4 +96,89 @@ public class AppTest {
         String secondPickupCity = response.path("pickupDetails.locations[1].contactDetails.address.cityName");
         Assert.assertEquals(secondPickupCity, "Oklahoma City", "Mismatch in second pickup city name");
     }
+
+    @Test
+    public void testUpdateDeliveryStatus() throws IOException {
+        String requestBody = readFileAsString("request/PostUpdateDeliveryRequest.json");
+
+        Response response = given()
+                .header("channel-id", "WEBOA")
+                .header("sub-channel-id", "WEB")
+                .header("Content-type", "application/json")
+                .and()
+                .body(requestBody)
+                .when()
+                .post("/brand/ARB/delivery")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on expected response structure
+        Assert.assertTrue(responseBody.contains("\"message\":\"ACK\""));
+    }
+
+    @Test
+    public void testUpdateDeliveryStatusInvalidRequest() {
+        Response response = given()
+                .header("channel-id", "WEBOA")
+                .header("sub-channel-id", "WEB")
+                .header("Content-type", "application/json")
+                .and()
+                .body("{}")
+                .when()
+                .post("/brand/ARB/delivery")
+                .then()
+                .statusCode(400)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+    }
+
+    @Test
+    public void testUpdateDeliveryStatusServerError() throws IOException {
+        String requestBody = readFileAsString("request/PostUpdateDeliveryRequest.json");
+
+        Response response = given()
+                .header("channel-id", "WEBOA")
+                .header("sub-channel-id", "WEB")
+                .header("Content-type", "application/json")
+                .and()
+                .body(requestBody)
+                .when()
+                .post("/brand/ARB/delivery")
+                .then()
+                .statusCode(500)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+    }
+
+    @Test
+    public void testUpdateDeliveryStatusServiceUnavailable() throws IOException {
+        String requestBody = readFileAsString("request/PostUpdateDeliveryRequest.json");
+
+        Response response = given()
+                .header("channel-id", "WEBOA")
+                .header("sub-channel-id", "WEB")
+                .header("Content-type", "application/json")
+                .and()
+                .body(requestBody)
+                .when()
+                .post("/brand/ARB/delivery")
+                .then()
+                .statusCode(503)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+    }
 }


### PR DESCRIPTION
This PR adds automated tests for the `POST /brand/{brandId}/delivery` endpoint to update the delivery status. The following test scenarios are covered:

1. Successful Update
2. Invalid Request
3. Internal Server Error
4. Service Unavailable

The test data is added to `src/test/resources/request/PostUpdateDeliveryRequest.json` and the test cases are implemented in `src/test/java/com/example/AppTest.java`.

closes #<issue_number>