### PR TITLE
Disable Circuit Breaker Tests

### DIFF
--- a/src/test/java/com/example/AppTest.java
+++ b/src/test/java/com/example/AppTest.java
@@ -146,4 +146,97 @@ public class AppTest {
         // Check if laterTime (ISO 8601 format) is after earlierTime
         return java.time.Instant.parse(laterTime).isAfter(java.time.Instant.parse(earlierTime));
     }
+
+    @Test
+    public void testDisableCircuitBreaker() throws IOException {
+        String brandId = "validBrandId";
+        String circuitBreakerName = "validCircuitBreakerName";
+
+        Response response = given()
+                .pathParam("brandId", brandId)
+                .pathParam("circuitbreakername", circuitBreakerName)
+                .header("Content-type", "application/json")
+                .when()
+                .put("/fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/disable")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("\"name\":\"" + circuitBreakerName + "\""));
+        Assert.assertTrue(responseBody.contains("\"status\":\"DISABLED\""));
+    }
+
+    @Test
+    public void testDisableCircuitBreakerInvalidBrand() throws IOException {
+        String brandId = "invalidBrandId";
+        String circuitBreakerName = "validCircuitBreakerName";
+
+        Response response = given()
+                .pathParam("brandId", brandId)
+                .pathParam("circuitbreakername", circuitBreakerName)
+                .header("Content-type", "application/json")
+                .when()
+                .put("/fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/disable")
+                .then()
+                .statusCode(400)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("Unable to disable Circuit Breaker"));
+    }
+
+    @Test
+    public void testDisableCircuitBreakerInvalidName() throws IOException {
+        String brandId = "validBrandId";
+        String circuitBreakerName = "invalidCircuitBreakerName";
+
+        Response response = given()
+                .pathParam("brandId", brandId)
+                .pathParam("circuitbreakername", circuitBreakerName)
+                .header("Content-type", "application/json")
+                .when()
+                .put("/fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/disable")
+                .then()
+                .statusCode(400)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("Unable to disable Circuit Breaker"));
+    }
+
+    @Test
+    public void testDisableCircuitBreakerServiceDown() throws IOException {
+        String brandId = "validBrandId";
+        String circuitBreakerName = "validCircuitBreakerName";
+
+        Response response = given()
+                .pathParam("brandId", brandId)
+                .pathParam("circuitbreakername", circuitBreakerName)
+                .header("Content-type", "application/json")
+                .when()
+                .put("/fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/disable")
+                .then()
+                .statusCode(500)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("Unable to disable Circuit Breaker"));
+    }
 }


### PR DESCRIPTION
Implemented tests for the 'Disable Circuit Breaker' endpoint:

1. Positive Test: Disable a valid circuit breaker for a valid brand.
2. Negative Test: Attempt to disable a circuit breaker with an invalid brand ID.
3. Negative Test: Attempt to disable a circuit breaker with an invalid circuit breaker name.
4. Negative Test: Attempt to disable a circuit breaker when the service is down.

The tests cover various scenarios to ensure the endpoint behaves as expected under different conditions.