### PR TITLE
Circuit Breaker Controller Tests

### DIFF
--- a/src/test/java/com/example/AppTest.java
+++ b/src/test/java/com/example/AppTest.java
@@ -146,4 +146,50 @@ public class AppTest {
         // Check if laterTime (ISO 8601 format) is after earlierTime
         return java.time.Instant.parse(laterTime).isAfter(java.time.Instant.parse(earlierTime));
     }
+
+    @Test
+    public void testPutResetCircuitBreaker() throws IOException {
+        String requestBody = readFileAsString("request/PutResetCircuitBreakerRequest.json");
+
+        Response response = given()
+                .header("Content-type", "application/json")
+                .and()
+                .body(requestBody)
+                .when()
+                .put("/fulfillment/brand/SDI/resilience/circuitbreaker/exampleCircuitBreaker/reset")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("\"name\":\"exampleCircuitBreaker\""));
+        Assert.assertTrue(responseBody.contains("\"status\":\"CLOSED\""));
+    }
+
+    @Test
+    public void testPutDisableCircuitBreaker() throws IOException {
+        String requestBody = readFileAsString("request/PutDisableCircuitBreakerRequest.json");
+
+        Response response = given()
+                .header("Content-type", "application/json")
+                .and()
+                .body(requestBody)
+                .when()
+                .put("/fulfillment/brand/SDI/resilience/circuitbreaker/exampleCircuitBreaker/disable")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String responseBody = response.getBody().asString();
+        System.out.println(responseBody);
+
+        // Assertions based on the expected response structure
+        Assert.assertTrue(responseBody.contains("\"name\":\"exampleCircuitBreaker\""));
+        Assert.assertTrue(responseBody.contains("\"status\":\"DISABLED\""));
+    }
 }

--- a/src/test/resources/request/PutDisableCircuitBreakerRequest.json
+++ b/src/test/resources/request/PutDisableCircuitBreakerRequest.json
@@ -1,0 +1,4 @@
+{
+  "brandId": "SDI",
+  "circuitbreakername": "exampleCircuitBreaker"
+}

--- a/src/test/resources/request/PutResetCircuitBreakerRequest.json
+++ b/src/test/resources/request/PutResetCircuitBreakerRequest.json
@@ -1,0 +1,4 @@
+{
+  "brandId": "SDI",
+  "circuitbreakername": "exampleCircuitBreaker"
+}


### PR DESCRIPTION
Implemented tests for the Circuit Breaker Controller endpoints:

- Reset Circuit Breaker (`PUT /fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/reset`)
- Disable Circuit Breaker (`PUT /fulfillment/brand/{brandId}/resilience/circuitbreaker/{circuitbreakername}/disable`)

The tests cover the following scenarios:

- Successful reset of a circuit breaker
- Successful disable of a circuit breaker

The test data files have been added to the `src/test/resources/request` directory.